### PR TITLE
feat : RecyclingPostService 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sch/rezero/dto/recycling/recyclingPost/RecyclingPostCreateRequest.java
+++ b/src/main/java/com/sch/rezero/dto/recycling/recyclingPost/RecyclingPostCreateRequest.java
@@ -1,9 +1,8 @@
 package com.sch.rezero.dto.recycling.recyclingPost;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
-import java.util.List;
 
 public record RecyclingPostCreateRequest(
         @Size(max = 255)
@@ -17,8 +16,7 @@ public record RecyclingPostCreateRequest(
         @NotBlank
         String thumbNailImage,
 
-        @Size(max = 20)
-        @NotBlank
-        String category
+        @NotNull
+        Long categoryId
 ) {
 }

--- a/src/main/java/com/sch/rezero/dto/recycling/recyclingPost/RecyclingPostResponse.java
+++ b/src/main/java/com/sch/rezero/dto/recycling/recyclingPost/RecyclingPostResponse.java
@@ -7,13 +7,13 @@ public record RecyclingPostResponse(
         Long id,
         String title,
         String description,
-        String thumbNailImage,
+        String thumbNailImageUrl,
         String category,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         String userName,
 
-        List<Long> imageIds,
+        List<String> imageUrls,
         Integer commentCount,
         Integer scrapCount
 ) {

--- a/src/main/java/com/sch/rezero/dto/recycling/recyclingPost/RecyclingPostUpdateRequest.java
+++ b/src/main/java/com/sch/rezero/dto/recycling/recyclingPost/RecyclingPostUpdateRequest.java
@@ -10,7 +10,6 @@ public record RecyclingPostUpdateRequest(
         @Size(max = 255)
         String thumbNailImage,
 
-        @Size(max = 20)
-        String category
+        Long categoryId
 ) {
 }

--- a/src/main/java/com/sch/rezero/entity/recycling/RecyclingImage.java
+++ b/src/main/java/com/sch/rezero/entity/recycling/RecyclingImage.java
@@ -34,4 +34,9 @@ public class RecyclingImage {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public RecyclingImage(RecyclingPost post, RecyclingImage image) {
+        this.post = post;
+        this.imageUrl = image.getImageUrl();
+    }
 }

--- a/src/main/java/com/sch/rezero/entity/recycling/RecyclingPost.java
+++ b/src/main/java/com/sch/rezero/entity/recycling/RecyclingPost.java
@@ -58,7 +58,15 @@ public class RecyclingPost {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Scrap> scraps = new ArrayList<>();
 
-    public void update(String title, String description, String thumbNailImage, String category) {
+    public RecyclingPost(User user, String title, String description, String thumbNailImageUrl, Category category) {
+        this.user = user;
+        this.title = title;
+        this.description = description;
+        this.thumbNailImageUrl = thumbNailImageUrl;
+        this.category = category;
+    }
+
+    public void update(String title, String description, String thumbNailImage, Category category) {
         if (!this.title.equals(title) && title != null) {
             this.title = title;
         }
@@ -69,8 +77,12 @@ public class RecyclingPost {
             this.thumbNailImageUrl = thumbNailImage;
         }
 
-        if (!this.category.getCategory().equals(category) && category != null) {
-            this.category.update(category);
+        if (category != null) {
+            this.category = category;
         }
+    }
+
+    public void addImage(RecyclingImage image) {
+        this.images.add(image);
     }
 }

--- a/src/main/java/com/sch/rezero/mapper/recycling/RecyclingPostMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/recycling/RecyclingPostMapper.java
@@ -1,0 +1,16 @@
+package com.sch.rezero.mapper.recycling;
+
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostResponse;
+import com.sch.rezero.entity.recycling.RecyclingPost;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RecyclingPostMapper {
+    @Mapping(source = "category.category", target = "category")
+    @Mapping(source = "user.name", target = "username")
+    @Mapping(target = "imageUrls", expression = "java(recyclingPost.getImages().stream().map(image -> image.getImageUrl()).toList())")
+    @Mapping(target = "commentCount", expression = "java(recyclingPost.getComments().size())")
+    @Mapping(target = "scrapCount", expression = "java(recyclingPost.getScraps().size())")
+    RecyclingPostResponse toDto(RecyclingPost recyclingPost);
+}

--- a/src/main/java/com/sch/rezero/repository/recycling/CategoryRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.recycling;
+
+import com.sch.rezero.entity.recycling.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/sch/rezero/repository/recycling/QnaCommentRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/QnaCommentRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.recycling;
+
+import com.sch.rezero.entity.recycling.QnaComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QnaCommentRepository extends JpaRepository<QnaComment, Long> {
+}

--- a/src/main/java/com/sch/rezero/repository/recycling/RecyclingImageRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/RecyclingImageRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.recycling;
+
+import com.sch.rezero.entity.recycling.RecyclingImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecyclingImageRepository extends JpaRepository<RecyclingImage, Long> {
+}

--- a/src/main/java/com/sch/rezero/repository/recycling/RecyclingPostRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/RecyclingPostRepository.java
@@ -4,6 +4,9 @@ import com.sch.rezero.entity.recycling.RecyclingPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RecyclingPostRepository extends JpaRepository<RecyclingPost, Long> {
+    List<RecyclingPost> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/sch/rezero/repository/recycling/RecyclingPostRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/RecyclingPostRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.recycling;
+
+import com.sch.rezero.entity.recycling.RecyclingPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecyclingPostRepository extends JpaRepository<RecyclingPost, Long> {
+}

--- a/src/main/java/com/sch/rezero/repository/recycling/ScrapPostRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/ScrapPostRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.recycling;
+
+import com.sch.rezero.entity.recycling.Scrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScrapPostRepository extends JpaRepository<Scrap, Long> {
+}

--- a/src/main/java/com/sch/rezero/repository/user/UserRepository.java
+++ b/src/main/java/com/sch/rezero/repository/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.user;
+
+import com.sch.rezero.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/sch/rezero/service/service/RecyclingPostService.java
+++ b/src/main/java/com/sch/rezero/service/service/RecyclingPostService.java
@@ -1,0 +1,85 @@
+package com.sch.rezero.service.service;
+
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostCreateRequest;
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostResponse;
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostUpdateRequest;
+import com.sch.rezero.entity.recycling.Category;
+import com.sch.rezero.entity.recycling.RecyclingPost;
+import com.sch.rezero.entity.user.User;
+import com.sch.rezero.mapper.recycling.RecyclingPostMapper;
+import com.sch.rezero.repository.recycling.CategoryRepository;
+import com.sch.rezero.repository.recycling.RecyclingPostRepository;
+import com.sch.rezero.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class RecyclingPostService {
+    private final RecyclingPostRepository recyclingPostRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final RecyclingPostMapper recyclingPostMapper;
+
+    @Transactional
+    public RecyclingPostResponse create(Long userId,
+                                        RecyclingPostCreateRequest recyclingPostCreateRequest,
+                                        List<MultipartFile> recyclingImage) {
+        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+        Category category = categoryRepository.findById(recyclingPostCreateRequest.categoryId()).orElseThrow(NoSuchElementException::new);
+
+        RecyclingPost recyclingPost = new RecyclingPost(
+                user,
+                recyclingPostCreateRequest.title(),
+                recyclingPostCreateRequest.description(),
+                recyclingPostCreateRequest.thumbNailImage(),
+                category
+        );
+
+        //이미지 저장 - 추후 구현
+//        if (recyclingImage.isPresent()) {
+//              RecyclingImage image = new RecyclingImage(recyclingPost, imageUrl)
+//              recyclingPost.addImage(image);
+//            }
+//        }
+
+        recyclingPostRepository.save(recyclingPost);
+        return recyclingPostMapper.toDto(recyclingPost);
+    }
+
+    @Transactional(readOnly = true)
+    public RecyclingPostResponse find(Long postId) {
+        RecyclingPost recyclingPost = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
+        return recyclingPostMapper.toDto(recyclingPost);
+    }
+
+    @Transactional
+    public List<RecyclingPostResponse> findAllByUserId(Long userId) {
+        return recyclingPostRepository.findAllByUserId(userId).stream()
+                .map(recyclingPostMapper::toDto)
+                .toList();
+    }
+
+    @Transactional
+    public RecyclingPostResponse update(Long postId,
+                                        RecyclingPostUpdateRequest recyclingPostUpdateRequest) {
+        RecyclingPost recyclingPost = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
+        Category category = categoryRepository.findById(recyclingPostUpdateRequest.categoryId()).orElseThrow(NoSuchElementException::new);
+        recyclingPost.update(recyclingPostUpdateRequest.title(),
+                recyclingPostUpdateRequest.description(),
+                recyclingPostUpdateRequest.thumbNailImage(),
+                category);
+        return recyclingPostMapper.toDto(recyclingPost);
+    }
+
+    @Transactional
+    public void delete(Long postId) {
+        RecyclingPost post = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
+        recyclingPostRepository.delete(post);
+    }
+}


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
feat : RecyclingPostService 추가

---
## 주요 변경 사항
- Recycling 관련 Repository 추가
- User Repository 추가
- Mapper 사용을 위해 라이브러리 의존성 추가
- 엔티티에서 필요한 값만 받는 생성자 추가
- RecyclingPostService CRUD 추가

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->
- findAllByUserId 우선 리스트 반환으로 기본 설정해둠. 추후 페이징 구현해야 함 ㅜ 이건 같이 하자고,, 

---
