### PR TITLE
feat : Community 관련 커서 무한 스크롤 구현

### DIFF
--- a/src/main/java/com/sch/rezero/config/JpaConfig.java
+++ b/src/main/java/com/sch/rezero/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.sch.rezero.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableJpaAuditing
+@EnableScheduling
+public class JpaConfig {
+}

--- a/src/main/java/com/sch/rezero/dto/community/communityComment/CommunityCommentQuery.java
+++ b/src/main/java/com/sch/rezero/dto/community/communityComment/CommunityCommentQuery.java
@@ -1,0 +1,22 @@
+package com.sch.rezero.dto.community.communityComment;
+
+public record CommunityCommentQuery(
+        Long postId,
+        Long idAfter,
+        String cursor,
+        Integer size,
+        String sortField,
+        String sortDirection
+) {
+    public CommunityCommentQuery {
+        if (size == null) {
+            size = 20;
+        }
+        if (sortField == null) {
+            sortField = "createdAt";
+        }
+        if (sortDirection == null) {
+            sortDirection = "asc";
+        }
+    }
+}

--- a/src/main/java/com/sch/rezero/dto/community/communityComment/CommunityCommentResponse.java
+++ b/src/main/java/com/sch/rezero/dto/community/communityComment/CommunityCommentResponse.java
@@ -1,13 +1,20 @@
 package com.sch.rezero.dto.community.communityComment;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CommunityCommentResponse(
-    Long id,
-    String userName,
-    String content,
-    LocalDateTime createdAt,
-    LocalDateTime updatedAt
+        Long id,
+        Long parentId,
+        String userName,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<CommunityCommentResponse> children
 ) {
-
+    public CommunityCommentResponse {
+        if (children == null) {
+            children = List.of();
+        }
+    }
 }

--- a/src/main/java/com/sch/rezero/dto/community/communityPost/CommunityPostQuery.java
+++ b/src/main/java/com/sch/rezero/dto/community/communityPost/CommunityPostQuery.java
@@ -1,0 +1,24 @@
+package com.sch.rezero.dto.community.communityPost;
+
+public record CommunityPostQuery(
+        String title,
+        String description,
+        String userName,
+        Long idAfter,
+        String cursor,
+        Integer size,
+        String sortField,
+        String sortDirection
+) {
+    public CommunityPostQuery {
+        if (size == null) {
+            size = 20;
+        }
+        if (sortField == null) {
+            sortField = "createdAt";
+        }
+        if (sortDirection == null) {
+            sortDirection = "desc";
+        }
+    }
+}

--- a/src/main/java/com/sch/rezero/dto/community/like/LikeQuery.java
+++ b/src/main/java/com/sch/rezero/dto/community/like/LikeQuery.java
@@ -1,0 +1,22 @@
+package com.sch.rezero.dto.community.like;
+
+public record LikeQuery(
+        Long userId,
+        Long idAfter,
+        String cursor,
+        Integer size,
+        String sortField,
+        String sortDirection
+) {
+    public LikeQuery {
+        if (size == null) {
+            size = 20;
+        }
+        if (sortField == null) {
+            sortField = "createdAt";
+        }
+        if (sortDirection == null) {
+            sortDirection = "desc";
+        }
+    }
+}

--- a/src/main/java/com/sch/rezero/dto/community/like/LikeResponse.java
+++ b/src/main/java/com/sch/rezero/dto/community/like/LikeResponse.java
@@ -1,4 +1,4 @@
-package com.sch.rezero.dto.community.likes;
+package com.sch.rezero.dto.community.like;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/sch/rezero/mapper/community/CommunityCommentMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/community/CommunityCommentMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CommunityCommentMapper {
-
+  @Mapping(source = "parent.id", target = "parentId")
   @Mapping(target = "userName", source = "user.name")
   CommunityCommentResponse toCommunityCommentResponse(CommunityComment comment);
 }

--- a/src/main/java/com/sch/rezero/mapper/community/LikeMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/community/LikeMapper.java
@@ -1,6 +1,6 @@
 package com.sch.rezero.mapper.community;
 
-import com.sch.rezero.dto.community.likes.LikeResponse;
+import com.sch.rezero.dto.community.like.LikeResponse;
 import com.sch.rezero.entity.community.Like;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/com/sch/rezero/repository/community/CommunityCommentQueryRepository.java
+++ b/src/main/java/com/sch/rezero/repository/community/CommunityCommentQueryRepository.java
@@ -1,0 +1,12 @@
+package com.sch.rezero.repository.community;
+
+import com.sch.rezero.dto.community.communityComment.CommunityCommentQuery;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.entity.community.CommunityComment;
+
+import java.util.List;
+
+public interface CommunityCommentQueryRepository {
+    CursorPageResponse<CommunityComment> findAll(CommunityCommentQuery communityCommentQuery);
+    List<CommunityComment> findRepliesByParentIds(List<Long> parentIds);
+}

--- a/src/main/java/com/sch/rezero/repository/community/CommunityCommentRepository.java
+++ b/src/main/java/com/sch/rezero/repository/community/CommunityCommentRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
-
+public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long>, CommunityCommentQueryRepository {
 }

--- a/src/main/java/com/sch/rezero/repository/community/CommunityPostQueryRepository.java
+++ b/src/main/java/com/sch/rezero/repository/community/CommunityPostQueryRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.community;
+
+import com.sch.rezero.dto.community.communityPost.CommunityPostQuery;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.entity.community.CommunityPost;
+
+public interface CommunityPostQueryRepository {
+    CursorPageResponse<CommunityPost> findAll(CommunityPostQuery communityPostQuery);
+}

--- a/src/main/java/com/sch/rezero/repository/community/CommunityPostRepository.java
+++ b/src/main/java/com/sch/rezero/repository/community/CommunityPostRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long> {
-
+public interface CommunityPostRepository extends JpaRepository<CommunityPost, Long>, CommunityPostQueryRepository {
 }

--- a/src/main/java/com/sch/rezero/repository/community/LikeQueryRepository.java
+++ b/src/main/java/com/sch/rezero/repository/community/LikeQueryRepository.java
@@ -1,0 +1,9 @@
+package com.sch.rezero.repository.community;
+
+import com.sch.rezero.dto.community.like.LikeQuery;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.entity.community.Like;
+
+public interface LikeQueryRepository {
+    CursorPageResponse<Like> findAllByUserId(LikeQuery likeQuery);
+}

--- a/src/main/java/com/sch/rezero/repository/community/LikeRepository.java
+++ b/src/main/java/com/sch/rezero/repository/community/LikeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LikeRepository extends JpaRepository<Like, Long> {
-  boolean existsByUserAndCommunityPost(User user, CommunityPost communityPost);
-  void deleteByUserAndCommunityPost(User user, CommunityPost communityPost);
+public interface LikeRepository extends JpaRepository<Like, Long>, LikeQueryRepository {
+    boolean existsByUserAndCommunityPost(User user, CommunityPost communityPost);
+    void deleteByUserAndCommunityPost(User user, CommunityPost communityPost);
 }

--- a/src/main/java/com/sch/rezero/repository/community/impl/CommunityCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/community/impl/CommunityCommentQueryRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.sch.rezero.repository.community.impl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sch.rezero.dto.community.communityComment.CommunityCommentQuery;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.entity.community.CommunityComment;
+import com.sch.rezero.repository.community.CommunityCommentQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.sch.rezero.entity.community.QCommunityComment.communityComment;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunityCommentQueryRepositoryImpl implements CommunityCommentQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CursorPageResponse<CommunityComment> findAll(CommunityCommentQuery query) {
+        List<CommunityComment> comments = queryFactory.selectFrom(communityComment)
+                .where(
+                        query.postId() != null ? communityComment.communityPost.id.eq(query.postId()) : null,
+                        communityComment.parent.isNull(),
+                        buildCursorCondition(query)
+                )
+                .orderBy(sortResolve(query.sortDirection()))
+                .limit(query.size() + 1)
+                .fetch();
+
+        boolean hasNext = comments.size() > query.size();
+        if (hasNext) {
+            comments = comments.subList(0, query.size());
+        }
+
+        String nextCursor = null;
+        Long nextIdAfter = null;
+
+        if (!comments.isEmpty()) {
+            CommunityComment last = comments.get(comments.size() - 1);
+            nextCursor = String.valueOf(last.getCreatedAt());
+            nextIdAfter = last.getId();
+        }
+
+        return new CursorPageResponse<>(comments, nextCursor, nextIdAfter, query.size(), hasNext);
+    }
+
+    @Override
+    public List<CommunityComment> findRepliesByParentIds(List<Long> parentIds) {
+        return queryFactory.selectFrom(communityComment)
+                .where(communityComment.parent.id.in(parentIds))
+                .fetch();
+    }
+
+    private BooleanExpression buildCursorCondition(CommunityCommentQuery query) {
+        if (query.cursor() == null || query.idAfter() == null) {
+            return null;
+        }
+
+        boolean isDesc = "desc".equalsIgnoreCase(query.sortDirection());
+
+        LocalDateTime cursorTime = LocalDateTime.parse(query.cursor());
+        return isDesc ? communityComment.createdAt.lt(cursorTime).or(communityComment.createdAt.eq(cursorTime).and(communityComment.id.lt(query.idAfter())))
+                : communityComment.createdAt.gt(cursorTime).or(communityComment.createdAt.eq(cursorTime).and(communityComment.id.gt(query.idAfter())));
+    }
+
+    private OrderSpecifier<?>[] sortResolve(String sortDirection) {
+        Order order = ("desc").equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+
+        return new OrderSpecifier[]{new OrderSpecifier<>(order, communityComment.createdAt), new OrderSpecifier<>(order, communityComment.id)};
+    }
+}

--- a/src/main/java/com/sch/rezero/repository/community/impl/CommunityPostQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/community/impl/CommunityPostQueryRepositoryImpl.java
@@ -1,0 +1,96 @@
+package com.sch.rezero.repository.community.impl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sch.rezero.dto.community.communityPost.CommunityPostQuery;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.entity.community.CommunityPost;
+import com.sch.rezero.repository.community.CommunityPostQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.sch.rezero.entity.community.QCommunityPost.communityPost;
+import static com.sch.rezero.entity.community.QLike.like;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunityPostQueryRepositoryImpl implements CommunityPostQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CursorPageResponse<CommunityPost> findAll(CommunityPostQuery query) {
+        //1. 데이터 조회
+        List<CommunityPost> posts = queryFactory.selectFrom(communityPost)
+                .where(
+                        query.title() != null ? communityPost.title.containsIgnoreCase(query.title()) : null,
+                        query.description() != null ? communityPost.description.containsIgnoreCase(query.description()) : null,
+                        query.userName() != null ? communityPost.user.name.contains(query.userName()) : null,
+                        buildCursorCondition(query)
+                )
+                .orderBy(sortResolve(query.sortField(), query.sortDirection()))
+                .limit(query.size() + 1)
+                .fetch();
+
+        //2. 다음 페이지 여부
+        boolean hasNext = posts.size() > query.size();
+        if (hasNext) {
+            posts = posts.subList(0, query.size());
+        }
+
+        //3. 다음 커서 계산
+        String nextCursor = null;
+        Long nextIdAfter = null;
+
+        if (!posts.isEmpty()) {
+            CommunityPost last = posts.get(posts.size() - 1);
+            nextCursor = "createdAt".equalsIgnoreCase(query.sortField())
+                    ? last.getCreatedAt().toString() : String.valueOf(last.getLikes().size());
+            nextIdAfter = last.getId();
+        }
+
+        return new CursorPageResponse<>(posts, nextCursor, nextIdAfter, query.size(), hasNext);
+    }
+
+    private BooleanExpression buildCursorCondition(CommunityPostQuery query) {
+        if (query.cursor() == null || query.idAfter() == null) {
+            return null;
+        }
+
+        boolean isDesc = "desc".equalsIgnoreCase(query.sortDirection());
+
+        if ("like".equalsIgnoreCase(query.sortField())) {
+            var expr = likeCountExpr();
+            Long cursorValue = Long.valueOf(query.cursor());
+            return isDesc ? expr.lt(cursorValue).or(expr.eq(cursorValue).and(communityPost.id.lt(query.idAfter())))
+                    : expr.gt(cursorValue).or(expr.eq(cursorValue).and(communityPost.id.gt(query.idAfter())));
+        } else {
+            return isDesc ? communityPost.id.lt(query.idAfter()) : communityPost.id.gt(query.idAfter());
+        }
+    }
+
+    private OrderSpecifier<?>[] sortResolve(String sortField, String sortDirection) {
+        Order order = "desc".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+
+        if ("like".equalsIgnoreCase(sortField)) {
+            return new OrderSpecifier[]{new OrderSpecifier<>(order, likeCountExpr()),
+                    new OrderSpecifier<>(order, communityPost.id)};
+        } else {
+            return new OrderSpecifier[]{new OrderSpecifier<>(order, communityPost.createdAt),
+                    new OrderSpecifier<>(order, communityPost.id)};
+        }
+    }
+
+    private NumberExpression<Long> likeCountExpr() {
+        return Expressions.asNumber(JPAExpressions
+                .select(like.count())
+                .from(like)
+                .where(like.communityPost.eq(communityPost)));
+    }
+}

--- a/src/main/java/com/sch/rezero/repository/community/impl/LikeQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/community/impl/LikeQueryRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.sch.rezero.repository.community.impl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sch.rezero.dto.community.like.LikeQuery;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.entity.community.Like;
+import com.sch.rezero.repository.community.LikeQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.sch.rezero.entity.community.QLike.like;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeQueryRepositoryImpl implements LikeQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CursorPageResponse<Like> findAllByUserId(LikeQuery query) {
+        List<Like> likes = queryFactory.selectFrom(like)
+                .where(
+                        query.userId() != null ? like.user.id.eq(query.userId()) : null,
+                        buildCursorCondition(query)
+                )
+                .orderBy(sortResolve(query.sortDirection()))
+                .limit(query.size() + 1)
+                .fetch();
+
+        boolean hasNext = likes.size() > query.size();
+        if (hasNext) {
+            likes = likes.subList(0, query.size());
+        }
+
+        String nextCursor = null;
+        Long nextIdAfter = null;
+
+        if (!likes.isEmpty()) {
+            Like last = likes.get(likes.size() - 1);
+            nextCursor = String.valueOf(last.getCreatedAt());
+            nextIdAfter = last.getId();
+        }
+
+        return new CursorPageResponse<>(likes, nextCursor, nextIdAfter, query.size(), hasNext);
+    }
+
+    private BooleanExpression buildCursorCondition(LikeQuery query) {
+        if (query.cursor() == null || query.idAfter() == null) {
+            return null;
+        }
+
+        boolean isDesc = "desc".equalsIgnoreCase(query.sortDirection());
+
+        LocalDateTime cursorTime = LocalDateTime.parse(query.cursor());
+        return isDesc ? like.createdAt.lt(cursorTime).or(like.createdAt.eq(cursorTime).and(like.id.lt(query.idAfter())))
+                : like.createdAt.gt(cursorTime).or(like.createdAt.eq(cursorTime).and(like.id.gt(query.idAfter())));
+    }
+
+
+    private OrderSpecifier<?>[] sortResolve(String sortDirection) {
+        Order order = ("desc").equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+
+        return new OrderSpecifier[]{new OrderSpecifier<>(order, like.createdAt),
+                new OrderSpecifier<>(order, like.id)};
+    }
+}

--- a/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
+++ b/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
@@ -1,8 +1,10 @@
 package com.sch.rezero.service.community;
 
 import com.sch.rezero.dto.community.communityComment.CommunityCommentCreateRequest;
+import com.sch.rezero.dto.community.communityComment.CommunityCommentQuery;
 import com.sch.rezero.dto.community.communityComment.CommunityCommentResponse;
 import com.sch.rezero.dto.community.communityComment.CommunityCommentUpdateRequest;
+import com.sch.rezero.dto.response.CursorPageResponse;
 import com.sch.rezero.entity.community.CommunityComment;
 import com.sch.rezero.entity.community.CommunityPost;
 import com.sch.rezero.entity.user.User;
@@ -11,79 +13,127 @@ import com.sch.rezero.repository.community.CommunityCommentRepository;
 import com.sch.rezero.repository.community.CommunityPostRepository;
 import com.sch.rezero.repository.user.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommunityCommentService {
 
-  private final CommunityCommentRepository communityCommentRepository;
-  private final CommunityPostRepository communityPostRepository;
-  private final UserRepository userRepository;
-  private final CommunityCommentMapper communityCommentMapper;
+    private final CommunityCommentRepository communityCommentRepository;
+    private final CommunityPostRepository communityPostRepository;
+    private final UserRepository userRepository;
+    private final CommunityCommentMapper communityCommentMapper;
 
-  @Transactional
-  public CommunityCommentResponse create(Long userId,
-      Long communityPostId, CommunityCommentCreateRequest communityCommentCreateRequest) {
+    @Transactional
+    public CommunityCommentResponse create(Long userId,
+                                           Long communityPostId, CommunityCommentCreateRequest communityCommentCreateRequest) {
 
-    User user = validateUserId(userId);
+        User user = validateUserId(userId);
 
-    CommunityPost communityPost = validateCommunityPostId(communityPostId);
+        CommunityPost communityPost = validateCommunityPostId(communityPostId);
 
-    CommunityComment parent = communityCommentRepository.findById(communityCommentCreateRequest.parentId()).orElse(null);
+        CommunityComment parent = communityCommentRepository.findById(communityCommentCreateRequest.parentId()).orElse(null);
 
-    CommunityComment communityComment = new CommunityComment(
-        user,
-        communityPost,
-        parent,
-        communityCommentCreateRequest.content()
-    );
+        CommunityComment communityComment = new CommunityComment(
+                user,
+                communityPost,
+                parent,
+                communityCommentCreateRequest.content()
+        );
 
-    communityCommentRepository.save(communityComment);
-    return communityCommentMapper.toCommunityCommentResponse(communityComment);
-  }
-
-  public CommunityCommentResponse update(Long userId, Long communityPostId, Long communityCommentId,
-      CommunityCommentUpdateRequest communityCommentUpdateRequest) {
-
-    CommunityPost communityPost = validateCommunityPostId(communityPostId);
-    CommunityComment communityComment = validateCommunityCommentId(communityCommentId);
-
-    if(!communityComment.getUser().getId().equals(userId)) {
-      throw new EntityNotFoundException("요청한 ID와 실제 댓글 ID가 다릅니다.");
+        communityCommentRepository.save(communityComment);
+        return communityCommentMapper.toCommunityCommentResponse(communityComment);
     }
 
-    communityComment.update(communityCommentUpdateRequest.content());
-    return communityCommentMapper.toCommunityCommentResponse(communityComment);
-  }
+    @Transactional(readOnly = true)
+    public CursorPageResponse<CommunityCommentResponse> findAll(CommunityCommentQuery query) {
+        if (!communityPostRepository.existsById(query.postId())) {
+            throw new NoSuchElementException("해당 게시글을 찾을 수 없습니다");
+        }
 
-  public void delete(Long userId, Long communityPostId, Long communityCommentId) {
-    CommunityPost communityPost = validateCommunityPostId(communityPostId);
-    CommunityComment communityComment = validateCommunityCommentId(communityCommentId);
+        CursorPageResponse<CommunityComment> parentComments = communityCommentRepository.findAll(query);
+        List<Long> parentIds = parentComments.content().stream()
+                .map(CommunityComment::getId)
+                .toList();
 
-    if(!communityComment.getUser().getId().equals(userId)) {
-      throw new EntityNotFoundException("요청한 ID와 실제 댓글 ID가 다릅니다.");
+        List<CommunityComment> replies = communityCommentRepository.findRepliesByParentIds(parentIds);
+
+        var groupedReplies = replies.stream()
+                .collect(Collectors.groupingBy(c -> c.getParent().getId()));
+
+        List<CommunityCommentResponse> responseList = parentComments.content().stream()
+                .map(parent -> {
+                    var parentDto = communityCommentMapper.toCommunityCommentResponse(parent);
+                    var childDtos = groupedReplies.getOrDefault(parent.getId(), List.of()).stream()
+                            .map(communityCommentMapper::toCommunityCommentResponse)
+                            .toList();
+
+                    return new CommunityCommentResponse(
+                            parentDto.id(),
+                            parentDto.parentId(),
+                            parentDto.userName(),
+                            parentDto.content(),
+                            parentDto.createdAt(),
+                            parentDto.updatedAt(),
+                            childDtos
+                    );
+                })
+                .toList();
+
+        return new CursorPageResponse<>(
+                responseList,
+                parentComments.nextCursor(),
+                parentComments.nextIdAfter(),
+                parentComments.size(),
+                parentComments.hasNext()
+        );
+
     }
 
-    communityCommentRepository.delete(communityComment);
+    public CommunityCommentResponse update(Long userId, Long communityPostId, Long communityCommentId,
+                                           CommunityCommentUpdateRequest communityCommentUpdateRequest) {
 
-  }
+        CommunityPost communityPost = validateCommunityPostId(communityPostId);
+        CommunityComment communityComment = validateCommunityCommentId(communityCommentId);
 
-  private User validateUserId(Long userId) {
-    return userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
-  }
+        if (!communityComment.getUser().getId().equals(userId)) {
+            throw new EntityNotFoundException("요청한 ID와 실제 댓글 ID가 다릅니다.");
+        }
 
-  private CommunityPost validateCommunityPostId(Long communityPostId) {
-    return communityPostRepository.findById(communityPostId)
-        .orElseThrow(NoSuchElementException::new);
-  }
+        communityComment.update(communityCommentUpdateRequest.content());
+        return communityCommentMapper.toCommunityCommentResponse(communityComment);
+    }
 
-  private CommunityComment validateCommunityCommentId(Long communityCommentId) {
-    return communityCommentRepository.findById(communityCommentId)
-        .orElseThrow(NoSuchElementException::new);
-  }
+    public void delete(Long userId, Long communityPostId, Long communityCommentId) {
+        CommunityPost communityPost = validateCommunityPostId(communityPostId);
+        CommunityComment communityComment = validateCommunityCommentId(communityCommentId);
+
+        if (!communityComment.getUser().getId().equals(userId)) {
+            throw new EntityNotFoundException("요청한 ID와 실제 댓글 ID가 다릅니다.");
+        }
+
+        communityCommentRepository.delete(communityComment);
+
+    }
+
+    private User validateUserId(Long userId) {
+        return userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+    }
+
+    private CommunityPost validateCommunityPostId(Long communityPostId) {
+        return communityPostRepository.findById(communityPostId)
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+    private CommunityComment validateCommunityCommentId(Long communityCommentId) {
+        return communityCommentRepository.findById(communityCommentId)
+                .orElseThrow(NoSuchElementException::new);
+    }
 
 }

--- a/src/main/java/com/sch/rezero/service/community/CommunityPostService.java
+++ b/src/main/java/com/sch/rezero/service/community/CommunityPostService.java
@@ -1,82 +1,99 @@
 package com.sch.rezero.service.community;
 
 import com.sch.rezero.dto.community.communityPost.CommunityPostCreateRequest;
+import com.sch.rezero.dto.community.communityPost.CommunityPostQuery;
 import com.sch.rezero.dto.community.communityPost.CommunityPostResponse;
 import com.sch.rezero.dto.community.communityPost.CommunityPostUpdateRequest;
+import com.sch.rezero.dto.response.CursorPageResponse;
 import com.sch.rezero.entity.community.CommunityPost;
 import com.sch.rezero.entity.user.User;
 import com.sch.rezero.mapper.community.CommunityPostMapper;
 import com.sch.rezero.repository.community.CommunityPostRepository;
 import com.sch.rezero.repository.user.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class CommunityPostService {
 
-  private final CommunityPostRepository communityPostRepository;
-  private final UserRepository userRepository;
-  private final CommunityPostMapper communityPostMapper;
+    private final CommunityPostRepository communityPostRepository;
+    private final UserRepository userRepository;
+    private final CommunityPostMapper communityPostMapper;
 
-  @Transactional
-  public CommunityPostResponse create(Long userId, CommunityPostCreateRequest communityPostCreate,
-      List<MultipartFile> communityPostImages) {
+    @Transactional
+    public CommunityPostResponse create(Long userId, CommunityPostCreateRequest communityPostCreate,
+                                        List<MultipartFile> communityPostImages) {
 
-    User user = ValidateUserId(userId);
-    CommunityPost communityPost = new CommunityPost(
-        user,
-        communityPostCreate.title(),
-        communityPostCreate.description(),
-        communityPostCreate.thumbNailImage()
-    );
+        User user = ValidateUserId(userId);
+        CommunityPost communityPost = new CommunityPost(
+                user,
+                communityPostCreate.title(),
+                communityPostCreate.description(),
+                communityPostCreate.thumbNailImage()
+        );
 
-    communityPostRepository.save(communityPost);
-    return communityPostMapper.toCommunityPostResponse(communityPost);
-  }
-
-  @Transactional(readOnly = true)
-  public CommunityPostResponse findByPostId(Long communityPostId) {
-    CommunityPost communityPost = validateCommunityPostId(communityPostId);
-
-    return communityPostMapper.toCommunityPostResponse(communityPost);
-  }
-
-  @Transactional
-  public CommunityPostResponse update(Long userId, Long postId, CommunityPostUpdateRequest communityUpdateCreate) {
-    CommunityPost communityPost = validateCommunityPostId(postId);
-
-    if (!communityPost.getUser().getId().equals(userId)) {
-      throw new EntityNotFoundException("요청한 ID와 실제 ID가 다릅니다.");
+        communityPostRepository.save(communityPost);
+        return communityPostMapper.toCommunityPostResponse(communityPost);
     }
 
-    communityPost.update(communityUpdateCreate.title(), communityUpdateCreate.description());
-    return communityPostMapper.toCommunityPostResponse(communityPost);
-  }
+    @Transactional(readOnly = true)
+    public CommunityPostResponse findByPostId(Long communityPostId) {
+        CommunityPost communityPost = validateCommunityPostId(communityPostId);
 
-  @Transactional
-  public void delete(Long userId, Long communityPostId) {
-    CommunityPost communityPost = validateCommunityPostId(communityPostId);
-
-    if (!communityPost.getUser().getId().equals(userId)) {
-      throw new EntityNotFoundException("요청한 ID와 실제 ID가 다릅니다.");
-
+        return communityPostMapper.toCommunityPostResponse(communityPost);
     }
 
-    communityPostRepository.delete(communityPost);
-  }
+    @Transactional(readOnly = true)
+    public CursorPageResponse<CommunityPostResponse> findAll(CommunityPostQuery query) {
+        CursorPageResponse<CommunityPost> result = communityPostRepository.findAll(query);
+        List<CommunityPostResponse> contents = result.content().stream().map(communityPostMapper::toCommunityPostResponse).toList();
 
-  private User ValidateUserId(Long userId) {
-    return userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
-  }
+        return new CursorPageResponse<>(
+                contents,
+                result.nextCursor(),
+                result.nextIdAfter(),
+                result.size(),
+                result.hasNext()
+        );
+    }
 
-  private CommunityPost validateCommunityPostId(Long communityPostId) {
-    return communityPostRepository.findById(communityPostId)
-        .orElseThrow(NoSuchElementException::new);
-  }
+    @Transactional
+    public CommunityPostResponse update(Long userId, Long postId, CommunityPostUpdateRequest communityUpdateCreate) {
+        CommunityPost communityPost = validateCommunityPostId(postId);
+
+        if (!communityPost.getUser().getId().equals(userId)) {
+            throw new EntityNotFoundException("요청한 ID와 실제 ID가 다릅니다.");
+        }
+
+        communityPost.update(communityUpdateCreate.title(), communityUpdateCreate.description());
+        return communityPostMapper.toCommunityPostResponse(communityPost);
+    }
+
+    @Transactional
+    public void delete(Long userId, Long communityPostId) {
+        CommunityPost communityPost = validateCommunityPostId(communityPostId);
+
+        if (!communityPost.getUser().getId().equals(userId)) {
+            throw new EntityNotFoundException("요청한 ID와 실제 ID가 다릅니다.");
+
+        }
+
+        communityPostRepository.delete(communityPost);
+    }
+
+    private User ValidateUserId(Long userId) {
+        return userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+    }
+
+    private CommunityPost validateCommunityPostId(Long communityPostId) {
+        return communityPostRepository.findById(communityPostId)
+                .orElseThrow(NoSuchElementException::new);
+    }
 }

--- a/src/main/java/com/sch/rezero/service/community/LikeService.java
+++ b/src/main/java/com/sch/rezero/service/community/LikeService.java
@@ -1,6 +1,6 @@
 package com.sch.rezero.service.community;
 
-import com.sch.rezero.dto.community.likes.LikeResponse;
+import com.sch.rezero.dto.community.like.LikeResponse;
 import com.sch.rezero.entity.community.CommunityPost;
 import com.sch.rezero.entity.community.Like;
 import com.sch.rezero.entity.user.User;

--- a/src/main/java/com/sch/rezero/service/community/LikeService.java
+++ b/src/main/java/com/sch/rezero/service/community/LikeService.java
@@ -1,6 +1,8 @@
 package com.sch.rezero.service.community;
 
+import com.sch.rezero.dto.community.like.LikeQuery;
 import com.sch.rezero.dto.community.like.LikeResponse;
+import com.sch.rezero.dto.response.CursorPageResponse;
 import com.sch.rezero.entity.community.CommunityPost;
 import com.sch.rezero.entity.community.Like;
 import com.sch.rezero.entity.user.User;
@@ -8,43 +10,59 @@ import com.sch.rezero.mapper.community.LikeMapper;
 import com.sch.rezero.repository.community.CommunityPostRepository;
 import com.sch.rezero.repository.community.LikeRepository;
 import com.sch.rezero.repository.user.UserRepository;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
 public class LikeService {
 
-  private final LikeRepository likeRepository;
-  private final UserRepository userRepository;
-  private final CommunityPostRepository communityPostRepository;
-  private final LikeMapper likeMapper;
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final CommunityPostRepository communityPostRepository;
+    private final LikeMapper likeMapper;
 
-  @Transactional
-  public LikeResponse createLike(Long userId, Long communityPostId) {
-    User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
-    CommunityPost communityPost = communityPostRepository.findById(communityPostId)
-        .orElseThrow(NoSuchElementException::new);
+    @Transactional
+    public LikeResponse createLike(Long userId, Long communityPostId) {
+        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+        CommunityPost communityPost = communityPostRepository.findById(communityPostId)
+                .orElseThrow(NoSuchElementException::new);
 
-    if (likeRepository.existsByUserAndCommunityPost(user, communityPost)) {
-      throw new IllegalArgumentException("User and Community Post already exist");
+        if (likeRepository.existsByUserAndCommunityPost(user, communityPost)) {
+            throw new IllegalArgumentException("User and Community Post already exist");
+        }
+
+        Like like = new Like(communityPost, user);
+        likeRepository.save(like);
+
+        return likeMapper.toLikeResponse(like);
     }
 
-    Like like = new Like(communityPost, user);
-    likeRepository.save(like);
+    @Transactional(readOnly = true)
+    public CursorPageResponse<LikeResponse> findAllByUserId(LikeQuery query) {
+        CursorPageResponse<Like> result = likeRepository.findAllByUserId(query);
+        List<LikeResponse> contents = result.content().stream().map(likeMapper::toLikeResponse).toList();
 
-    return likeMapper.toLikeResponse(like);
-  }
+        return new CursorPageResponse<>(
+                contents,
+                result.nextCursor(),
+                result.nextIdAfter(),
+                result.size(),
+                result.hasNext()
+        );
+    }
 
-  @Transactional
-  public void delete(Long userId, Long communityPostId) {
-    User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
-    CommunityPost communityPost = communityPostRepository.findById(communityPostId)
-        .orElseThrow(NoSuchElementException::new);
+    @Transactional
+    public void delete(Long userId, Long communityPostId) {
+        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+        CommunityPost communityPost = communityPostRepository.findById(communityPostId)
+                .orElseThrow(NoSuchElementException::new);
 
-    likeRepository.deleteByUserAndCommunityPost(user, communityPost);
-  }
+        likeRepository.deleteByUserAndCommunityPost(user, communityPost);
+    }
 
 }


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
feat : Community 관련 커서 무한 스크롤 구현

---
## 주요 변경 사항
- Community 관련 Query Dto 추가
- Community 관련 Query Repository 추가 및 인터페이스 확장
- 커서 기반 무한 스크롤 구현
- Service에 findAll() 구현

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->


---
