### PR TITLE
refactor: Recycling 커서 페이지네이션 로직 일부 수정

### DIFF
--- a/src/main/java/com/sch/rezero/repository/recycling/impl/QnaCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/impl/QnaCommentQueryRepositoryImpl.java
@@ -70,7 +70,7 @@ public class QnaCommentQueryRepositoryImpl implements QnaCommentQueryRepository 
     }
 
     private OrderSpecifier<?>[] sortResolve(String sortDirection) {
-        Order order = ("desc").equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+        Order order = "desc".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
 
         return new OrderSpecifier[]{new OrderSpecifier<>(order, qnaComment.createdAt),
                 new OrderSpecifier<>(order, qnaComment.id)};

--- a/src/main/java/com/sch/rezero/repository/recycling/impl/RecyclingPostQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/impl/RecyclingPostQueryRepositoryImpl.java
@@ -50,11 +50,8 @@ public class RecyclingPostQueryRepositoryImpl implements RecyclingPostQueryRepos
 
         if (!posts.isEmpty()) {
             RecyclingPost last = posts.get(posts.size() - 1);
-            nextCursor = switch (query.sortField()) {
-                case "title" -> last.getTitle();
-                case "scrap" -> String.valueOf(last.getScraps().size());
-                default -> String.valueOf(last.getId());
-            };
+            nextCursor = "createdAt".equalsIgnoreCase(query.sortField())
+                    ? last.getCreatedAt().toString() : String.valueOf(last.getScraps().size());
             nextIdAfter = last.getId();
         }
 
@@ -66,9 +63,9 @@ public class RecyclingPostQueryRepositoryImpl implements RecyclingPostQueryRepos
             return null;
         }
 
-        boolean isDesc = ("desc").equalsIgnoreCase(query.sortDirection());
+        boolean isDesc = "desc".equalsIgnoreCase(query.sortDirection());
 
-        if (query.sortField().equalsIgnoreCase("scrap")) {
+        if ("scrap".equalsIgnoreCase(query.sortField())) {
             var expr = scrapCountExpr();
             Long cursorValue = Long.valueOf(query.cursor());
             return isDesc ? expr.lt(cursorValue).or(expr.eq(cursorValue).and(recyclingPost.id.lt(query.idAfter())))
@@ -79,17 +76,16 @@ public class RecyclingPostQueryRepositoryImpl implements RecyclingPostQueryRepos
     }
 
     private OrderSpecifier<?>[] sortResolve(String sortField, String sortDirection) {
-        Order order = ("desc").equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+        Order order = "desc".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
 
 
-        if (sortField.equalsIgnoreCase("scrap")) {
+        if ("like".equalsIgnoreCase(sortField)) {
             return new OrderSpecifier[]{new OrderSpecifier<>(order, scrapCountExpr()),
                     new OrderSpecifier<>(order, recyclingPost.id)};
         } else {
             return new OrderSpecifier[]{new OrderSpecifier<>(order, recyclingPost.id)};
         }
     }
-
 
     private NumberExpression<Long> scrapCountExpr() {
         return Expressions.asNumber(JPAExpressions

--- a/src/main/java/com/sch/rezero/repository/recycling/impl/ScrapQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/impl/ScrapQueryRepositoryImpl.java
@@ -63,7 +63,7 @@ public class ScrapQueryRepositoryImpl implements ScrapQueryRepository {
 
 
     private OrderSpecifier<?>[] sortResolve(String sortDirection) {
-        Order order = ("desc").equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+        Order order = "desc".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
 
         return new OrderSpecifier[]{new OrderSpecifier<>(order, scrap.createdAt),
                 new OrderSpecifier<>(order, scrap.id)};

--- a/src/main/java/com/sch/rezero/service/recycling/QnaCommentService.java
+++ b/src/main/java/com/sch/rezero/service/recycling/QnaCommentService.java
@@ -41,8 +41,8 @@ public class QnaCommentService {
     }
 
     @Transactional(readOnly = true)
-    public CursorPageResponse<QnaCommentResponse> findAllByPost(QnaCommentQuery query) {
-        if (recyclingPostRepository.existsById(query.postId())) {
+    public CursorPageResponse<QnaCommentResponse> findAllByPostId(QnaCommentQuery query) {
+        if (!recyclingPostRepository.existsById(query.postId())) {
             throw new NoSuchElementException("해당 게시글을 찾을 수 없습니다");
         }
 

--- a/src/main/java/com/sch/rezero/service/recycling/ScrapService.java
+++ b/src/main/java/com/sch/rezero/service/recycling/ScrapService.java
@@ -1,7 +1,9 @@
 package com.sch.rezero.service.recycling;
 
 import com.sch.rezero.dto.recycling.scrap.ScrapCreateRequest;
+import com.sch.rezero.dto.recycling.scrap.ScrapQuery;
 import com.sch.rezero.dto.recycling.scrap.ScrapResponse;
+import com.sch.rezero.dto.response.CursorPageResponse;
 import com.sch.rezero.entity.recycling.RecyclingPost;
 import com.sch.rezero.entity.recycling.Scrap;
 import com.sch.rezero.entity.user.User;
@@ -40,10 +42,17 @@ public class ScrapService {
     }
 
     @Transactional(readOnly = true)
-    public List<ScrapResponse> findAllByPostId(Long postId) {
-        return scrapRepository.findAllByPostId(postId).stream()
-                .map(scrapMapper::toResponse)
-                .toList();
+    public CursorPageResponse<ScrapResponse> findAllByUserId(ScrapQuery query) {
+        CursorPageResponse<Scrap> result = scrapRepository.findAllByUserId(query);
+        List<ScrapResponse> contents = result.content().stream().map(scrapMapper::toResponse).toList();
+
+        return new CursorPageResponse<>(
+                contents,
+                result.nextCursor(),
+                result.nextIdAfter(),
+                result.size(),
+                result.hasNext()
+        );
     }
 
     @Transactional


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
refactor: Recycling 커서 페이지네이션 로직 일부 수정

---
## 주요 변경 사항
- 커서 조건문 일부 로직 수정 (`!` 조건 추가)
- nextCursor 및 idAfter 계산 방식 보완
- LikeService에 findAllByUserId() 메서드 추가

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->
#17  feat : Recycling 관련 커서 무한 스크롤 구현 

---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->


---
