### PR TITLE
feat: 환경 레벨 테스트 기능 구현

### DIFF
--- a/src/main/java/com/sch/rezero/controller/EnvironmentController.java
+++ b/src/main/java/com/sch/rezero/controller/EnvironmentController.java
@@ -30,7 +30,8 @@ public class EnvironmentController {
     Long userId = (user != null) ? user.getId() : null;
 
     if (userId == null) {
-
+      UserAnswerResponse answer = userAnswerService.createWithoutSaving(userAnswerRequests);
+      return ResponseEntity.status(HttpStatus.OK).body(answer);
     }
 
     UserAnswerResponse answer = userAnswerService.create(userId, userAnswerRequests);

--- a/src/main/java/com/sch/rezero/controller/EnvironmentController.java
+++ b/src/main/java/com/sch/rezero/controller/EnvironmentController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/environment")
+@RequestMapping("/api/environment")
 public class EnvironmentController {
 
   private final UserAnswerService userAnswerService;
@@ -33,6 +33,23 @@ public class EnvironmentController {
       UserAnswerResponse answer = userAnswerService.createWithoutSaving(userAnswerRequests);
       return ResponseEntity.status(HttpStatus.OK).body(answer);
     }
+
+    UserAnswerResponse answer = userAnswerService.create(userId, userAnswerRequests);
+    return ResponseEntity.status(HttpStatus.OK).body(answer);
+  }
+
+  @PostMapping("/redo")
+  public ResponseEntity<UserAnswerResponse> update(
+      @RequestBody List<UserAnswerRequest> userAnswerRequests,
+      HttpSession session
+  ) {
+    User user = (User) session.getAttribute("user");
+
+    if (user == null) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    Long userId = user.getId();
 
     UserAnswerResponse answer = userAnswerService.create(userId, userAnswerRequests);
     return ResponseEntity.status(HttpStatus.OK).body(answer);

--- a/src/main/java/com/sch/rezero/controller/EnvironmentController.java
+++ b/src/main/java/com/sch/rezero/controller/EnvironmentController.java
@@ -1,0 +1,39 @@
+package com.sch.rezero.controller;
+
+import com.sch.rezero.dto.environment.userAnswer.UserAnswerRequest;
+import com.sch.rezero.dto.environment.userAnswer.UserAnswerResponse;
+import com.sch.rezero.entity.user.User;
+import com.sch.rezero.service.environment.UserAnswerService;
+import jakarta.servlet.http.HttpSession;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/environment")
+public class EnvironmentController {
+
+  private final UserAnswerService userAnswerService;
+
+  @PostMapping
+  public ResponseEntity<UserAnswerResponse> create(
+      @RequestBody List<UserAnswerRequest> userAnswerRequests,
+      HttpSession session
+  ) {
+    User user = (User) session.getAttribute("user");
+    Long userId = (user != null) ? user.getId() : null;
+
+    if (userId == null) {
+
+    }
+
+    UserAnswerResponse answer = userAnswerService.create(userId, userAnswerRequests);
+    return ResponseEntity.status(HttpStatus.OK).body(answer);
+  }
+}

--- a/src/main/java/com/sch/rezero/dto/environment/userAnswer/UserAnswerRequest.java
+++ b/src/main/java/com/sch/rezero/dto/environment/userAnswer/UserAnswerRequest.java
@@ -1,0 +1,8 @@
+package com.sch.rezero.dto.environment.userAnswer;
+
+public record UserAnswerRequest (
+    Long questionId,
+    Long answerId
+) {
+
+}

--- a/src/main/java/com/sch/rezero/dto/environment/userAnswer/UserAnswerResponse.java
+++ b/src/main/java/com/sch/rezero/dto/environment/userAnswer/UserAnswerResponse.java
@@ -1,0 +1,8 @@
+package com.sch.rezero.dto.environment.userAnswer;
+
+public record UserAnswerResponse(
+    String level,
+    int totalScore
+) {
+
+}

--- a/src/main/java/com/sch/rezero/entity/environment/Answer.java
+++ b/src/main/java/com/sch/rezero/entity/environment/Answer.java
@@ -1,0 +1,37 @@
+package com.sch.rezero.entity.environment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "answers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Answer {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "question_id", nullable = false)
+  private Question question;
+
+  @Column(nullable = false)
+  private String answer;
+
+  @Column(nullable = false)
+  private int score;
+}

--- a/src/main/java/com/sch/rezero/entity/environment/Level.java
+++ b/src/main/java/com/sch/rezero/entity/environment/Level.java
@@ -1,0 +1,32 @@
+package com.sch.rezero.entity.environment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "levels")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Level {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String name;
+
+  private int min_score;
+
+  private int max_score;
+
+}

--- a/src/main/java/com/sch/rezero/entity/environment/Question.java
+++ b/src/main/java/com/sch/rezero/entity/environment/Question.java
@@ -1,0 +1,31 @@
+package com.sch.rezero.entity.environment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "questions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Question {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String question;
+
+}

--- a/src/main/java/com/sch/rezero/entity/environment/Question.java
+++ b/src/main/java/com/sch/rezero/entity/environment/Question.java
@@ -2,12 +2,9 @@ package com.sch.rezero.entity.environment;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/sch/rezero/entity/environment/UserAnswer.java
+++ b/src/main/java/com/sch/rezero/entity/environment/UserAnswer.java
@@ -1,0 +1,36 @@
+package com.sch.rezero.entity.environment;
+
+import com.sch.rezero.entity.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "user_answers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserAnswer {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "answer_id", nullable = false)
+  private Answer answer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+}

--- a/src/main/java/com/sch/rezero/entity/environment/UserAnswer.java
+++ b/src/main/java/com/sch/rezero/entity/environment/UserAnswer.java
@@ -33,4 +33,8 @@ public class UserAnswer {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  public UserAnswer(Answer answer, User user) {
+    this.answer = answer;
+    this.user = user;
+  }
 }

--- a/src/main/java/com/sch/rezero/mapper/environment/UserAnswerMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/environment/UserAnswerMapper.java
@@ -4,7 +4,7 @@ import com.sch.rezero.dto.environment.userAnswer.UserAnswerResponse;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
-public interface userAnswerMapper {
+public interface UserAnswerMapper {
 
   UserAnswerResponse toUserAnswerResponse(String level, int totalScore);
 }

--- a/src/main/java/com/sch/rezero/mapper/environment/userAnswerMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/environment/userAnswerMapper.java
@@ -1,0 +1,10 @@
+package com.sch.rezero.mapper.environment;
+
+import com.sch.rezero.dto.environment.userAnswer.UserAnswerResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface userAnswerMapper {
+
+  UserAnswerResponse toUserAnswerResponse(String level, int totalScore);
+}

--- a/src/main/java/com/sch/rezero/repository/environment/AnswerRepository.java
+++ b/src/main/java/com/sch/rezero/repository/environment/AnswerRepository.java
@@ -1,0 +1,8 @@
+package com.sch.rezero.repository.environment;
+
+import com.sch.rezero.entity.environment.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+}

--- a/src/main/java/com/sch/rezero/repository/environment/LevelRepository.java
+++ b/src/main/java/com/sch/rezero/repository/environment/LevelRepository.java
@@ -1,0 +1,8 @@
+package com.sch.rezero.repository.environment;
+
+import com.sch.rezero.entity.environment.Level;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LevelRepository extends JpaRepository<Level, Long> {
+
+}

--- a/src/main/java/com/sch/rezero/repository/environment/LevelRepository.java
+++ b/src/main/java/com/sch/rezero/repository/environment/LevelRepository.java
@@ -1,8 +1,13 @@
 package com.sch.rezero.repository.environment;
 
 import com.sch.rezero.entity.environment.Level;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LevelRepository extends JpaRepository<Level, Long> {
 
+  @Query("SELECT l FROM Level l WHERE :score BETWEEN l.min_score AND l.max_score")
+  Optional<Level> findLevelByScore(@Param("score") int score);
 }

--- a/src/main/java/com/sch/rezero/repository/environment/QuestionRepository.java
+++ b/src/main/java/com/sch/rezero/repository/environment/QuestionRepository.java
@@ -1,0 +1,8 @@
+package com.sch.rezero.repository.environment;
+
+import com.sch.rezero.entity.environment.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+}

--- a/src/main/java/com/sch/rezero/repository/environment/UserAnswerRepository.java
+++ b/src/main/java/com/sch/rezero/repository/environment/UserAnswerRepository.java
@@ -1,0 +1,8 @@
+package com.sch.rezero.repository.environment;
+
+import com.sch.rezero.entity.environment.UserAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
+
+}

--- a/src/main/java/com/sch/rezero/repository/environment/UserAnswerRepository.java
+++ b/src/main/java/com/sch/rezero/repository/environment/UserAnswerRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserAnswerRepository extends JpaRepository<UserAnswer, Long> {
 
+  void deleteAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/sch/rezero/service/environment/UserAnswerService.java
+++ b/src/main/java/com/sch/rezero/service/environment/UserAnswerService.java
@@ -49,6 +49,24 @@ public class UserAnswerService {
     return userAnswerMapper.toUserAnswerResponse(level, totalScore);
   }
 
+  @Transactional
+  public UserAnswerResponse createWithoutSaving(List<UserAnswerRequest> userAnswerRequest) {
+    int totalScore = 0;
+
+    for (UserAnswerRequest req : userAnswerRequest) {
+      Answer answer = answerRepository.findById(req.answerId())
+          .orElseThrow(() -> new NoSuchElementException("Answer with id " + req.answerId() + " not found"));
+
+      totalScore += answer.getScore();
+    }
+
+    String level = levelRepository.findLevelByScore(totalScore)
+        .map(Level::getName).orElseThrow(() -> new NoSuchElementException("Level not found"));
+
+    return userAnswerMapper.toUserAnswerResponse(level, totalScore);
+  }
+
+
   private User validateUserId(Long userId) {
     return userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
   }

--- a/src/main/java/com/sch/rezero/service/environment/UserAnswerService.java
+++ b/src/main/java/com/sch/rezero/service/environment/UserAnswerService.java
@@ -1,0 +1,59 @@
+package com.sch.rezero.service.environment;
+
+import com.sch.rezero.dto.environment.userAnswer.UserAnswerRequest;
+import com.sch.rezero.dto.environment.userAnswer.UserAnswerResponse;
+import com.sch.rezero.entity.environment.Answer;
+import com.sch.rezero.entity.environment.Level;
+import com.sch.rezero.entity.environment.UserAnswer;
+import com.sch.rezero.entity.user.User;
+import com.sch.rezero.mapper.environment.UserAnswerMapper;
+import com.sch.rezero.repository.environment.AnswerRepository;
+import com.sch.rezero.repository.environment.LevelRepository;
+import com.sch.rezero.repository.environment.UserAnswerRepository;
+import com.sch.rezero.repository.user.UserRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAnswerService {
+
+  private final UserAnswerRepository userAnswerRepository;
+  private final UserRepository userRepository;
+  private final AnswerRepository answerRepository;
+  private final LevelRepository levelRepository;
+  private final UserAnswerMapper userAnswerMapper;
+
+  @Transactional
+  public UserAnswerResponse create(Long userId, List<UserAnswerRequest> userAnswerRequest) {
+    User user = validateUserId(userId);
+
+    int totalScore = 0;
+
+    for (UserAnswerRequest req : userAnswerRequest) {
+      Answer answer = answerRepository.findById(req.answerId())
+          .orElseThrow(() -> new NoSuchElementException("Answer with id " + req.answerId() + " not found"));
+
+      UserAnswer userAnswer = new UserAnswer(answer, user);
+      userAnswerRepository.save(userAnswer);
+
+      totalScore += answer.getScore();
+    }
+
+    String level = levelRepository.findLevelByScore(totalScore)
+        .map(Level::getName).orElseThrow(() -> new NoSuchElementException("Level not found"));
+
+    return userAnswerMapper.toUserAnswerResponse(level, totalScore);
+  }
+
+  private User validateUserId(Long userId) {
+    return userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+  }
+
+
+
+}

--- a/src/main/java/com/sch/rezero/service/environment/UserAnswerService.java
+++ b/src/main/java/com/sch/rezero/service/environment/UserAnswerService.java
@@ -13,7 +13,6 @@ import com.sch.rezero.repository.environment.UserAnswerRepository;
 import com.sch.rezero.repository.user.UserRepository;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -12,6 +12,11 @@ DROP TABLE IF EXISTS community_images CASCADE;
 DROP TABLE IF EXISTS community_comments CASCADE;
 DROP TABLE IF EXISTS community_likes CASCADE;
 
+DROP TABLE IF EXISTS questions CASCADE;
+DROP TABLE IF EXISTS answers CASCADE;
+DROP TABLE IF EXISTS user_answers CASCADE;
+DROP TABLE iF EXISTS levels CASCADE;
+
 CREATE TABLE IF NOT EXISTS users
 (
     id          BIGSERIAL PRIMARY KEY,
@@ -22,13 +27,13 @@ CREATE TABLE IF NOT EXISTS users
     birth       DATE,
     region      VARCHAR(100),
     profile_url VARCHAR(255)
-    );
+);
 
 CREATE TABLE IF NOT EXISTS categories
 (
     id       BIGSERIAL PRIMARY KEY,
     category VARCHAR(20) NOT NULL
-    );
+);
 
 CREATE TABLE IF NOT EXISTS recycling_posts
 (
@@ -42,10 +47,10 @@ CREATE TABLE IF NOT EXISTS recycling_posts
     category_id      BIGINT       NOT NULL,
 
     CONSTRAINT fk_users_to_recycling_posts FOREIGN KEY (user_id)
-    REFERENCES users (id) ON DELETE CASCADE,
+        REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT fk_categories_to_recycling_posts FOREIGN KEY (category_id)
-    REFERENCES categories (id) ON DELETE RESTRICT
-    );
+        REFERENCES categories (id) ON DELETE RESTRICT
+);
 
 CREATE TABLE IF NOT EXISTS recycling_images
 (
@@ -56,8 +61,8 @@ CREATE TABLE IF NOT EXISTS recycling_images
     updated_at   timestamptz,
 
     CONSTRAINT fk_recycling_posts_to_recycling_images FOREIGN KEY (recycling_id)
-    REFERENCES recycling_posts (id) ON DELETE CASCADE
-    );
+        REFERENCES recycling_posts (id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS qna_comments
 (
@@ -70,12 +75,12 @@ CREATE TABLE IF NOT EXISTS qna_comments
     updated_at   timestamptz,
 
     CONSTRAINT fk_recycling_posts_to_qna_comments FOREIGN KEY (recycling_id)
-    REFERENCES recycling_posts (id) ON DELETE CASCADE,
+        REFERENCES recycling_posts (id) ON DELETE CASCADE,
     CONSTRAINT fk_users_to_qna_comments FOREIGN KEY (user_id)
-    REFERENCES users (id) ON DELETE CASCADE,
+        REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT fk_qna_comments_to_qna_comments FOREIGN KEY (parent_id)
-    REFERENCES qna_comments (id) ON DELETE CASCADE
-    );
+        REFERENCES qna_comments (id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS scraps
 (
@@ -85,10 +90,10 @@ CREATE TABLE IF NOT EXISTS scraps
     created_at   timestamptz NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_recycling_posts_to_scraps FOREIGN KEY (recycling_id)
-    REFERENCES recycling_posts (id) ON DELETE CASCADE,
+        REFERENCES recycling_posts (id) ON DELETE CASCADE,
     CONSTRAINT fk_users_to_scraps FOREIGN KEY (user_id)
-    REFERENCES users (id) ON DELETE CASCADE
-    );
+        REFERENCES users (id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS follows
 (
@@ -98,11 +103,11 @@ CREATE TABLE IF NOT EXISTS follows
     created_at   timestamptz NOT NULL DEFAULT NOW(),
 
     CONSTRAINT fk_users_to_follows_1 FOREIGN KEY (following_id)
-    REFERENCES users (id) ON DELETE CASCADE,
+        REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT fk_users_to_follows_2 FOREIGN KEY (follower_id)
-    REFERENCES users (id) ON DELETE CASCADE,
+        REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT uq_follows UNIQUE (following_id, follower_id)
-    );
+);
 
 
 CREATE TABLE IF NOT EXISTS community_posts
@@ -116,8 +121,8 @@ CREATE TABLE IF NOT EXISTS community_posts
     thumb_nail_image VARCHAR(255) NOT NULL,
 
     CONSTRAINT fk_users_to_community_posts FOREIGN KEY (user_id)
-    REFERENCES users (id) ON DELETE CASCADE
-    );
+        REFERENCES users (id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS community_images
 (
@@ -128,8 +133,8 @@ CREATE TABLE IF NOT EXISTS community_images
     updated_at   timestamptz,
 
     CONSTRAINT fk_community_posts_to_community_images FOREIGN KEY (community_id)
-    REFERENCES community_posts (id) ON DELETE CASCADE
-    );
+        REFERENCES community_posts (id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS community_comments
 (
@@ -142,12 +147,12 @@ CREATE TABLE IF NOT EXISTS community_comments
     updated_at   timestamptz,
 
     CONSTRAINT fk_community_posts_to_community_comments FOREIGN KEY (community_id)
-    REFERENCES community_posts (id) ON DELETE CASCADE,
+        REFERENCES community_posts (id) ON DELETE CASCADE,
     CONSTRAINT fk_users_to_community_comments FOREIGN KEY (user_id)
-    REFERENCES users (id) ON DELETE CASCADE,
+        REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT fk_community_comments_to_community_comments FOREIGN KEY (parent_id)
-    REFERENCES community_comments (id) ON DELETE CASCADE
-    );
+        REFERENCES community_comments (id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS community_likes
 (
@@ -162,4 +167,41 @@ CREATE TABLE IF NOT EXISTS community_likes
         REFERENCES users (id) ON DELETE CASCADE,
 
     CONSTRAINT uq_community_likes UNIQUE (community_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS questions
+(
+    id       BIGSERIAL PRIMARY KEY NOT NULL,
+    question VARCHAR(255)          NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS answers
+(
+    id          BIGSERIAL PRIMARY KEY NOT NULL,
+    question_id BIGINT                NOT NULL,
+    answer      VARCHAR(255)          NOT NULL,
+    score       INT                   NOT NULL,
+
+    CONSTRAINT fk_questions_to_answers FOREIGN KEY (question_id)
+        REFERENCES questions (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS user_answers
+(
+    id        BIGSERIAL PRIMARY KEY NOT NULL,
+    user_id   BIGINT                NOT NULL,
+    answer_id BIGINT                NOT NULL,
+
+    CONSTRAINT fk_users_to_user_answers FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_answers_to_user_answers FOREIGN KEY (answer_id)
+        REFERENCES answers (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS levels
+(
+    id        BIGSERIAL PRIMARY KEY NOT NULL,
+    name      VARCHAR(50)           NOT NULL,
+    min_score INT,
+    max_score INT
 );


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
feat: 환경 레벨 테스트 기능 구현

---
## 주요 변경 사항
테스트시 레벨 저장(비회원은 저장 x)
재테스트시 다시 레벨 저장 (회원만)


---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->
지금은 답변을 루프마다 save() 불러서 저장하고 있는데.. 한번에 저장할 수 있도록 리팩토링을 해보겟소.. 이슈까진 아니고,,,,

---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->
기능 또 머가 필요할까.. 관리자가 질문/답변/레벨 만들 수 있는 기능....만들까..(귀찮아서 안만듦ㅎ..)

---
