### PR TITLE
feat: Recycling 관련 controller 구현

### DIFF
--- a/src/main/java/com/sch/rezero/controller/recycling/RecyclingPostController.java
+++ b/src/main/java/com/sch/rezero/controller/recycling/RecyclingPostController.java
@@ -1,0 +1,55 @@
+package com.sch.rezero.controller.recycling;
+
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostCreateRequest;
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostQuery;
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostResponse;
+import com.sch.rezero.dto.recycling.recyclingPost.RecyclingPostUpdateRequest;
+import com.sch.rezero.dto.response.CursorPageResponse;
+import com.sch.rezero.service.recycling.RecyclingPostService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/recycling-posts")
+public class RecyclingPostController {
+    private final RecyclingPostService recyclingPostService;
+
+    @GetMapping
+    public ResponseEntity<CursorPageResponse<RecyclingPostResponse>> findAll(RecyclingPostQuery query) {
+        CursorPageResponse<RecyclingPostResponse> posts = recyclingPostService.findAll(query);
+        return ResponseEntity.status(HttpStatus.OK).body(posts);
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<RecyclingPostResponse> findByPostId(@PathVariable Long postId) {
+        RecyclingPostResponse post = recyclingPostService.find(postId);
+        return ResponseEntity.status(HttpStatus.OK).body(post);
+    }
+
+    @PostMapping
+    public ResponseEntity<RecyclingPostResponse> create(HttpSession session, @RequestPart @Valid RecyclingPostCreateRequest request,
+                                                        @RequestPart List<MultipartFile> recyclingImage) {
+        RecyclingPostResponse post = recyclingPostService.create(session, request, recyclingImage);
+        return ResponseEntity.status(HttpStatus.CREATED).body(post);
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<RecyclingPostResponse> update(HttpSession session, @PathVariable Long postId,
+                                                        @RequestBody RecyclingPostUpdateRequest request) {
+        RecyclingPostResponse post = recyclingPostService.update(session, postId, request);
+        return ResponseEntity.status(HttpStatus.OK).body(post);
+    }
+
+    @DeleteMapping("/{postId}")
+    public void delete(HttpSession session, @PathVariable Long postId) {
+        recyclingPostService.delete(session, postId);
+    }
+}

--- a/src/main/java/com/sch/rezero/service/recycling/RecyclingPostService.java
+++ b/src/main/java/com/sch/rezero/service/recycling/RecyclingPostService.java
@@ -15,6 +15,7 @@ import com.sch.rezero.repository.recycling.CategoryRepository;
 import com.sch.rezero.repository.recycling.RecyclingImageRepository;
 import com.sch.rezero.repository.recycling.RecyclingPostRepository;
 import com.sch.rezero.repository.user.UserRepository;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,8 +34,9 @@ public class RecyclingPostService {
     private final RecyclingImageRepository recyclingImageRepository;
 
     @Transactional
-    public RecyclingPostResponse create(Long userId, RecyclingPostCreateRequest recyclingPostCreateRequest, List<MultipartFile> recyclingImage) {
-        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+    public RecyclingPostResponse create(HttpSession session, RecyclingPostCreateRequest recyclingPostCreateRequest, List<MultipartFile> recyclingImage) {
+        User loginUser = (User) session.getAttribute("user");
+        User user = userRepository.findById(loginUser.getId()).orElseThrow(NoSuchElementException::new);
         if (!(user.getRole() == Role.ADMIN)) {
             throw new IllegalStateException("관리자만 재활용법 게시물 작성이 가능합니다.");
         }
@@ -81,8 +83,9 @@ public class RecyclingPostService {
     }
 
     @Transactional
-    public RecyclingPostResponse update(Long userId, Long postId, RecyclingPostUpdateRequest recyclingPostUpdateRequest) {
-        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+    public RecyclingPostResponse update(HttpSession session, Long postId, RecyclingPostUpdateRequest recyclingPostUpdateRequest) {
+        User loginUser = (User) session.getAttribute("user");
+        User user = userRepository.findById(loginUser.getId()).orElseThrow(NoSuchElementException::new);
         RecyclingPost recyclingPost = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
         Category category = categoryRepository.findById(recyclingPostUpdateRequest.categoryId()).orElseThrow(NoSuchElementException::new);
 
@@ -99,8 +102,9 @@ public class RecyclingPostService {
     }
 
     @Transactional
-    public void delete(Long userId, Long postId) {
-        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+    public void delete(HttpSession session, Long postId) {
+        User loginUser = (User) session.getAttribute("user");
+        User user = userRepository.findById(loginUser.getId()).orElseThrow(NoSuchElementException::new);
         RecyclingPost post = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
 
         if (!user.getId().equals(post.getUser().getId())) {
@@ -111,8 +115,9 @@ public class RecyclingPostService {
     }
 
     @Transactional
-    public void deleteImage(Long userId, Long postId, Long imageId) {
-        User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
+    public void deleteImage(HttpSession session, Long postId, Long imageId) {
+        User loginUser = (User) session.getAttribute("user");
+        User user = userRepository.findById(loginUser.getId()).orElseThrow(NoSuchElementException::new);
         RecyclingPost post = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
         RecyclingImage image = recyclingImageRepository.findById(imageId).orElseThrow(NoSuchElementException::new);
 


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
feat: Recycling 관련 controller 구현

---
## 주요 변경 사항
- RecyclingPostController 구현
- 서비스에서 메서드 매개변수 Long에서 HttpSession으로 변경

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->
머지 나중에 다 하고 한번에 할게

---
