### PR TITLE
fix: session 관리 방식을 UserContext 기반으로 변경

### DIFF
--- a/src/main/java/com/sch/rezero/config/UserContext.java
+++ b/src/main/java/com/sch/rezero/config/UserContext.java
@@ -19,8 +19,7 @@ public class UserContext {
     }
 
     public User getCurrentUserOrNull() {
-        User user = (User) session.getAttribute("user");
-        return user;
+        return (User) session.getAttribute("user");
     }
 
     public Long getCurrentUserId() {

--- a/src/main/java/com/sch/rezero/config/UserContext.java
+++ b/src/main/java/com/sch/rezero/config/UserContext.java
@@ -18,6 +18,11 @@ public class UserContext {
         return user;
     }
 
+    public User getCurrentUserOrNull() {
+        User user = (User) session.getAttribute("user");
+        return user;
+    }
+
     public Long getCurrentUserId() {
         return getCurrentUser().getId();
     }

--- a/src/main/java/com/sch/rezero/controller/user/LoginController.java
+++ b/src/main/java/com/sch/rezero/controller/user/LoginController.java
@@ -1,4 +1,4 @@
-package com.sch.rezero.controller;
+package com.sch.rezero.controller.user;
 
 import com.sch.rezero.dto.user.auth.LoginRequest;
 import com.sch.rezero.dto.user.auth.LoginResponse;

--- a/src/main/java/com/sch/rezero/controller/user/UserController.java
+++ b/src/main/java/com/sch/rezero/controller/user/UserController.java
@@ -1,12 +1,11 @@
-package com.sch.rezero.controller;
+package com.sch.rezero.controller.user;
 
+import com.sch.rezero.config.UserContext;
 import com.sch.rezero.dto.user.profile.ProfileResponse;
 import com.sch.rezero.dto.user.profile.ProfileUpdateRequest;
 import com.sch.rezero.dto.user.profile.UserResponse;
-import com.sch.rezero.entity.user.User;
 import com.sch.rezero.service.user.ProfileService;
 import com.sch.rezero.service.user.UserService;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,37 +25,38 @@ public class UserController {
 
   private final ProfileService profileService;
   private final UserService userService;
+  private final UserContext userContext;
 
   // 본인 프로필 (my page)
   @GetMapping("/me")
-  public ResponseEntity<ProfileResponse> find(HttpSession session) {
-    User user = (User) session.getAttribute("user");
-
-    ProfileResponse profile = profileService.find(user.getId());
+  public ResponseEntity<ProfileResponse> find() {
+    userContext.getCurrentUser();
+    ProfileResponse profile = profileService.find(userContext.getCurrentUserId());
 
     return ResponseEntity.status(HttpStatus.OK).body(profile);
   }
 
   @PatchMapping("/me")
-  public ResponseEntity<ProfileResponse> update(
-      @RequestBody @Valid ProfileUpdateRequest profileUpdateRequest,
-      HttpSession session) {
-    User user = (User) session.getAttribute("user");
+  public ResponseEntity<ProfileResponse> update(@RequestBody @Valid ProfileUpdateRequest profileUpdateRequest) {
+    userContext.getCurrentUser();
+    ProfileResponse updated = profileService.update(userContext.getCurrentUserId(), profileUpdateRequest);
 
-    ProfileResponse updated = profileService.update(user.getId(), profileUpdateRequest);
     return ResponseEntity.status(HttpStatus.OK).body(updated);
   }
 
   @DeleteMapping("/me")
-  public void delete(HttpSession session) {
-    User user = (User) session.getAttribute("user");
-    profileService.delete(user.getId());
+  public ResponseEntity<Void> delete() {
+    userContext.getCurrentUser();
+    profileService.delete(userContext.getCurrentUserId());
+
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 
   // 상대 프로필
   @GetMapping("/users/{userId}")
   public ResponseEntity<UserResponse> findById(@PathVariable long userId) {
     UserResponse user = userService.findById(userId);
+
     return ResponseEntity.status(HttpStatus.OK).body(user);
   }
 


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
fix: session 관리 방식을 UserContext 기반으로 변경

---
## 주요 변경 사항
환경 레벨 테스트 비회원 접근 허용을 위해 UserContext에 세션 없을 경우 null 반환하는 getCurrentUserOrNull() 메서드 추가

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->
맞게한거겠죠오...

---
