### PR TITLE
feat: communityCommentController 구현

### DIFF
--- a/src/main/java/com/sch/rezero/controller/community/CommunityCommentController.java
+++ b/src/main/java/com/sch/rezero/controller/community/CommunityCommentController.java
@@ -1,0 +1,36 @@
+package com.sch.rezero.controller.community;
+
+import com.sch.rezero.config.UserContext;
+import com.sch.rezero.dto.community.communityComment.CommunityCommentCreateRequest;
+import com.sch.rezero.dto.community.communityComment.CommunityCommentResponse;
+import com.sch.rezero.entity.community.CommunityComment;
+import com.sch.rezero.service.community.CommunityCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/comments")
+public class CommunityCommentController {
+
+  private final CommunityCommentService communityCommentService;
+  private final UserContext userContext;
+
+  @PostMapping("{postId}")
+  public ResponseEntity<CommunityCommentResponse> create(
+      @PathVariable Long postId,
+      @RequestBody CommunityCommentCreateRequest request
+  ) {
+    Long userId = userContext.getCurrentUserId();
+    CommunityCommentResponse created = communityCommentService.create(postId, userId, request);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(created);
+  }
+
+}

--- a/src/main/java/com/sch/rezero/controller/community/CommunityCommentController.java
+++ b/src/main/java/com/sch/rezero/controller/community/CommunityCommentController.java
@@ -9,6 +9,7 @@ import com.sch.rezero.service.community.CommunityCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,6 +47,11 @@ public class CommunityCommentController {
     return ResponseEntity.status(HttpStatus.OK).body(updated);
   }
 
+  @DeleteMapping("{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    Long userId = userContext.getCurrentUserId();
+    communityCommentService.delete(id, userId);
 
-
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
 }

--- a/src/main/java/com/sch/rezero/controller/community/CommunityCommentController.java
+++ b/src/main/java/com/sch/rezero/controller/community/CommunityCommentController.java
@@ -3,11 +3,13 @@ package com.sch.rezero.controller.community;
 import com.sch.rezero.config.UserContext;
 import com.sch.rezero.dto.community.communityComment.CommunityCommentCreateRequest;
 import com.sch.rezero.dto.community.communityComment.CommunityCommentResponse;
+import com.sch.rezero.dto.community.communityComment.CommunityCommentUpdateRequest;
 import com.sch.rezero.entity.community.CommunityComment;
 import com.sch.rezero.service.community.CommunityCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,5 +34,18 @@ public class CommunityCommentController {
 
     return ResponseEntity.status(HttpStatus.CREATED).body(created);
   }
+
+  @PatchMapping("{id}")
+  public ResponseEntity<CommunityCommentResponse> update(
+      @PathVariable Long id,
+      @RequestBody CommunityCommentUpdateRequest request
+  ) {
+    Long userId = userContext.getCurrentUserId();
+    CommunityCommentResponse updated = communityCommentService.update(id, userId, request);
+
+    return ResponseEntity.status(HttpStatus.OK).body(updated);
+  }
+
+
 
 }

--- a/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
+++ b/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
@@ -96,7 +96,7 @@ public class CommunityCommentService {
 
     }
 
-    public CommunityCommentResponse update(Long userId, Long id,
+    public CommunityCommentResponse update(Long id, Long userId,
                                            CommunityCommentUpdateRequest communityCommentUpdateRequest) {
 
         CommunityComment comment = communityCommentRepository.findById(id)

--- a/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
+++ b/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
@@ -110,8 +110,7 @@ public class CommunityCommentService {
         return communityCommentMapper.toCommunityCommentResponse(comment);
     }
 
-    public void delete(Long userId, Long communityPostId, Long communityCommentId) {
-        CommunityPost communityPost = validateCommunityPostId(communityPostId);
+    public void delete(Long userId, Long communityCommentId) {
         CommunityComment communityComment = validateCommunityCommentId(communityCommentId);
 
         if (!communityComment.getUser().getId().equals(userId)) {

--- a/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
+++ b/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
@@ -38,7 +38,13 @@ public class CommunityCommentService {
 
         CommunityPost communityPost = validateCommunityPostId(communityPostId);
 
-        CommunityComment parent = communityCommentRepository.findById(communityCommentCreateRequest.parentId()).orElse(null);
+        CommunityComment parent = null;
+        Long parentId = communityCommentCreateRequest.parentId();
+
+        if (parentId != null) {
+            parent = communityCommentRepository.findById(parentId)
+                .orElseThrow(() -> new EntityNotFoundException("Parent comment not found"));
+        }
 
         CommunityComment communityComment = new CommunityComment(
                 user,

--- a/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
+++ b/src/main/java/com/sch/rezero/service/community/CommunityCommentService.java
@@ -96,18 +96,18 @@ public class CommunityCommentService {
 
     }
 
-    public CommunityCommentResponse update(Long userId, Long communityPostId, Long communityCommentId,
+    public CommunityCommentResponse update(Long userId, Long id,
                                            CommunityCommentUpdateRequest communityCommentUpdateRequest) {
 
-        CommunityPost communityPost = validateCommunityPostId(communityPostId);
-        CommunityComment communityComment = validateCommunityCommentId(communityCommentId);
+        CommunityComment comment = communityCommentRepository.findById(id)
+            .orElseThrow(EntityNotFoundException::new);
 
-        if (!communityComment.getUser().getId().equals(userId)) {
+        if (!comment.getUser().getId().equals(userId)) {
             throw new EntityNotFoundException("요청한 ID와 실제 댓글 ID가 다릅니다.");
         }
 
-        communityComment.update(communityCommentUpdateRequest.content());
-        return communityCommentMapper.toCommunityCommentResponse(communityComment);
+        comment.update(communityCommentUpdateRequest.content());
+        return communityCommentMapper.toCommunityCommentResponse(comment);
     }
 
     public void delete(Long userId, Long communityPostId, Long communityCommentId) {


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
feat: communityCommentController 구현

---
## 주요 변경 사항
대댓글 로직 변경했슴당 기존에 null로 날리는거는.. parent가 무조건 있어야해서 오류가 나길래...

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->
기본적인 거 다 끝났어요. 페이지네이션이랑 사진만 하면 내가 맡은 기능은 다 끝날 듯 얏호!

---
