### PR TITLE
refactor: recycling controller 수정 완료

### DIFF
--- a/src/main/java/com/sch/rezero/controller/recycling/QnaCommentController.java
+++ b/src/main/java/com/sch/rezero/controller/recycling/QnaCommentController.java
@@ -21,7 +21,8 @@ public class QnaCommentController {
     private final UserContext userContext;
 
     @GetMapping("/{postId}")
-    public ResponseEntity<CursorPageResponse<QnaCommentResponse>> findAllByPostId(@PathVariable Long postId, QnaCommentQuery query) {
+    public ResponseEntity<CursorPageResponse<QnaCommentResponse>> findAllByPostId(@PathVariable Long postId,
+                                                                                  @ModelAttribute QnaCommentQuery query) {
         var comment = qnaCommentService.findAllByPostId(postId, query);
         return ResponseEntity.status(HttpStatus.OK).body(comment);
     }

--- a/src/main/java/com/sch/rezero/controller/recycling/RecyclingPostController.java
+++ b/src/main/java/com/sch/rezero/controller/recycling/RecyclingPostController.java
@@ -10,6 +10,7 @@ import com.sch.rezero.service.recycling.RecyclingPostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,9 +36,9 @@ public class RecyclingPostController {
         return ResponseEntity.status(HttpStatus.OK).body(post);
     }
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<RecyclingPostResponse> create(@RequestPart("request") @Valid RecyclingPostCreateRequest request,
-                                                        @RequestPart("images") List<MultipartFile> recyclingImage) {
+                                                        @RequestPart(value = "images", required = false) List<MultipartFile> recyclingImage) {
         RecyclingPostResponse post = recyclingPostService.create(userContext.getCurrentUserId(), request, recyclingImage);
         return ResponseEntity.status(HttpStatus.CREATED).body(post);
     }

--- a/src/main/java/com/sch/rezero/controller/recycling/ScrapController.java
+++ b/src/main/java/com/sch/rezero/controller/recycling/ScrapController.java
@@ -18,8 +18,8 @@ public class ScrapController {
     private final UserContext userContext;
 
     @GetMapping
-    public ResponseEntity<CursorPageResponse<ScrapResponse>> findAll(ScrapQuery query) {
-        var scraps = scrapService.findAllByUserId(query);
+    public ResponseEntity<CursorPageResponse<ScrapResponse>> findAll(@ModelAttribute ScrapQuery query) {
+        var scraps = scrapService.findAllByUserId(userContext.getCurrentUserId(),query);
         return ResponseEntity.status(HttpStatus.OK).body(scraps);
     }
 

--- a/src/main/java/com/sch/rezero/dto/recycling/scrap/ScrapQuery.java
+++ b/src/main/java/com/sch/rezero/dto/recycling/scrap/ScrapQuery.java
@@ -1,7 +1,6 @@
 package com.sch.rezero.dto.recycling.scrap;
 
 public record ScrapQuery(
-        Long userId,
         Long idAfter,
         String cursor,
         Integer size,

--- a/src/main/java/com/sch/rezero/mapper/community/CommunityCommentMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/community/CommunityCommentMapper.java
@@ -9,5 +9,6 @@ import org.mapstruct.Mapping;
 public interface CommunityCommentMapper {
   @Mapping(source = "parent.id", target = "parentId")
   @Mapping(target = "userName", source = "user.name")
+  @Mapping(target = "children", ignore = true)
   CommunityCommentResponse toCommunityCommentResponse(CommunityComment comment);
 }

--- a/src/main/java/com/sch/rezero/mapper/recycling/QnaCommentMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/recycling/QnaCommentMapper.java
@@ -9,5 +9,6 @@ import org.mapstruct.Mapping;
 public interface QnaCommentMapper {
     @Mapping(source = "parent.id", target = "parentId")
     @Mapping(source = "user.name", target = "userName")
+    @Mapping(target = "children", ignore = true)
     QnaCommentResponse toQnaCommentResponse(QnaComment qnaComment);
 }

--- a/src/main/java/com/sch/rezero/repository/recycling/CategoryRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/CategoryRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByCategory(String category);
+    Category findByCategory(String category);
 }

--- a/src/main/java/com/sch/rezero/repository/recycling/ScrapQueryRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/ScrapQueryRepository.java
@@ -5,5 +5,5 @@ import com.sch.rezero.dto.response.CursorPageResponse;
 import com.sch.rezero.entity.recycling.Scrap;
 
 public interface ScrapQueryRepository {
-    CursorPageResponse<Scrap> findAllByUserId(ScrapQuery scrapQuery);
+    CursorPageResponse<Scrap> findAllByUserId(Long userId, ScrapQuery scrapQuery);
 }

--- a/src/main/java/com/sch/rezero/repository/recycling/ScrapRepository.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/ScrapRepository.java
@@ -4,10 +4,11 @@ import com.sch.rezero.entity.recycling.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapQueryRepository {
     boolean existsByPostIdAndUserId(Long postId, Long userId);
-    List<Scrap> findAllByPostId(Long postId);
+
+    Optional<Scrap> findByPostId(Long postId);
 }

--- a/src/main/java/com/sch/rezero/repository/recycling/impl/RecyclingPostQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/impl/RecyclingPostQueryRepositoryImpl.java
@@ -50,8 +50,8 @@ public class RecyclingPostQueryRepositoryImpl implements RecyclingPostQueryRepos
 
         if (!posts.isEmpty()) {
             RecyclingPost last = posts.get(posts.size() - 1);
-            nextCursor = "createdAt".equalsIgnoreCase(query.sortField())
-                    ? last.getCreatedAt().toString() : String.valueOf(last.getScraps().size());
+            nextCursor = "scrap".equalsIgnoreCase(query.sortField())
+                    ? String.valueOf(last.getScraps().size()) : last.getCreatedAt().toString();
             nextIdAfter = last.getId();
         }
 
@@ -78,8 +78,7 @@ public class RecyclingPostQueryRepositoryImpl implements RecyclingPostQueryRepos
     private OrderSpecifier<?>[] sortResolve(String sortField, String sortDirection) {
         Order order = "desc".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
 
-
-        if ("like".equalsIgnoreCase(sortField)) {
+        if ("scrap".equalsIgnoreCase(sortField)) {
             return new OrderSpecifier[]{new OrderSpecifier<>(order, scrapCountExpr()),
                     new OrderSpecifier<>(order, recyclingPost.id)};
         } else {

--- a/src/main/java/com/sch/rezero/repository/recycling/impl/ScrapQueryRepositoryImpl.java
+++ b/src/main/java/com/sch/rezero/repository/recycling/impl/ScrapQueryRepositoryImpl.java
@@ -22,10 +22,10 @@ public class ScrapQueryRepositoryImpl implements ScrapQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public CursorPageResponse<Scrap> findAllByUserId(ScrapQuery query) {
+    public CursorPageResponse<Scrap> findAllByUserId(Long userId,ScrapQuery query) {
         List<Scrap> scraps = queryFactory.selectFrom(scrap)
                 .where(
-                        query.userId() != null ? scrap.user.id.eq(query.userId()) : null,
+                        scrap.user.id.eq(userId),
                         buildCursorCondition(query)
                 )
                 .orderBy(sortResolve(query.sortDirection()))

--- a/src/main/java/com/sch/rezero/service/recycling/QnaCommentService.java
+++ b/src/main/java/com/sch/rezero/service/recycling/QnaCommentService.java
@@ -12,6 +12,7 @@ import com.sch.rezero.mapper.recycling.QnaCommentMapper;
 import com.sch.rezero.repository.recycling.QnaCommentRepository;
 import com.sch.rezero.repository.recycling.RecyclingPostRepository;
 import com.sch.rezero.repository.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +33,14 @@ public class QnaCommentService {
     public QnaCommentResponse create(Long userId, Long postId, QnaCommentCreateRequest qnaCommentCreateRequest) {
         User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
         RecyclingPost recyclingPost = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
-        QnaComment parent = qnaCommentRepository.findById(qnaCommentCreateRequest.parentId()).orElse(null);
+
+        QnaComment parent = null;
+        Long parentId = qnaCommentCreateRequest.parentId();
+
+        if (parentId != null) {
+            parent = qnaCommentRepository.findById(parentId)
+                    .orElseThrow(() -> new EntityNotFoundException("Parent comment not found"));
+        }
 
         QnaComment qnaComment = new QnaComment(recyclingPost, user, parent, qnaCommentCreateRequest.content());
 

--- a/src/main/java/com/sch/rezero/service/recycling/RecyclingPostService.java
+++ b/src/main/java/com/sch/rezero/service/recycling/RecyclingPostService.java
@@ -85,7 +85,13 @@ public class RecyclingPostService {
     public RecyclingPostResponse update(Long userId, Long postId, RecyclingPostUpdateRequest recyclingPostUpdateRequest) {
         User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
         RecyclingPost recyclingPost = recyclingPostRepository.findById(postId).orElseThrow(NoSuchElementException::new);
-        Category category = categoryRepository.findById(recyclingPostUpdateRequest.categoryId()).orElseThrow(NoSuchElementException::new);
+        Category category;
+
+        if (recyclingPostUpdateRequest.categoryId() != null) {
+            category = categoryRepository.findById(recyclingPostUpdateRequest.categoryId()).orElseGet(() -> categoryRepository.findByCategory("기타"));
+        } else {
+            category = recyclingPostRepository.findById(postId).get().getCategory();
+        }
 
         if (!user.getId().equals(recyclingPost.getUser().getId())) {
             throw new IllegalArgumentException("본인이 작성한 게시물만 수정 가능합니다");

--- a/src/main/java/com/sch/rezero/service/recycling/ScrapService.java
+++ b/src/main/java/com/sch/rezero/service/recycling/ScrapService.java
@@ -39,8 +39,8 @@ public class ScrapService {
     }
 
     @Transactional(readOnly = true)
-    public CursorPageResponse<ScrapResponse> findAllByUserId(ScrapQuery query) {
-        CursorPageResponse<Scrap> result = scrapRepository.findAllByUserId(query);
+    public CursorPageResponse<ScrapResponse> findAllByUserId(Long userId, ScrapQuery query) {
+        CursorPageResponse<Scrap> result = scrapRepository.findAllByUserId(userId, query);
         List<ScrapResponse> contents = result.content().stream().map(scrapMapper::toResponse).toList();
 
         return new CursorPageResponse<>(
@@ -53,8 +53,8 @@ public class ScrapService {
     }
 
     @Transactional
-    public void delete(Long userId, Long scrapId) {
-        Scrap scrap = scrapRepository.findById(scrapId).orElseThrow(NoSuchElementException::new);
+    public void delete(Long userId, Long postId) {
+        Scrap scrap = scrapRepository.findByPostId(postId).orElseThrow(NoSuchElementException::new);
         User user = userRepository.findById(userId).orElseThrow(NoSuchElementException::new);
 
         if (!scrap.getUser().getId().equals(user.getId())) {


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
refactor: recycling controller 수정 완료

---
## 주요 변경 사항
- 컨트롤러에서 query 부분에 @ModelAttribute 추가
- 게시글 업데이트 시 카테고리 null이면 오류 발생했는데 바뀌지 않았으면 기존거 유지, 새로운 거로 변경 시 검증 후 변경 / 없을 시엔 기타로 저장되록 함
- 부모 댓글 Id가 존재할 경우에만 findById 실행
- Post create에 multipart/form-data 적용 및 required=false 옵션 추가

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->
테스트 완료 했엉
쿼리에서 userId 빼고 세션으로 로그인한 사용자 Id 전송하게 하니까 그 사람꺼만 나와요

---
