### PR TITLE
refactor: 재활용법 글쓰기 수정

### DIFF
--- a/src/main/java/com/sch/rezero/dto/recycling/category/CategoryResponse.java
+++ b/src/main/java/com/sch/rezero/dto/recycling/category/CategoryResponse.java
@@ -1,6 +1,7 @@
 package com.sch.rezero.dto.recycling.category;
 
 public record CategoryResponse(
+        Long categoryId,
         String category
 ) {
 }

--- a/src/main/java/com/sch/rezero/entity/community/CommunityPost.java
+++ b/src/main/java/com/sch/rezero/entity/community/CommunityPost.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -41,7 +40,6 @@ public class CommunityPost {
   @Column(nullable = false)
   private String title;
 
-  @Lob
   @Column(columnDefinition = "TEXT", nullable = false)
   private String description;
 

--- a/src/main/java/com/sch/rezero/entity/recycling/QnaComment.java
+++ b/src/main/java/com/sch/rezero/entity/recycling/QnaComment.java
@@ -33,7 +33,6 @@ public class QnaComment {
     @JoinColumn(name = "parent_id")
     private QnaComment parent;
 
-    @Lob
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 

--- a/src/main/java/com/sch/rezero/entity/recycling/RecyclingPost.java
+++ b/src/main/java/com/sch/rezero/entity/recycling/RecyclingPost.java
@@ -30,7 +30,6 @@ public class RecyclingPost {
     @Column(nullable = false)
     private String title;
 
-    @Lob
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
 

--- a/src/main/java/com/sch/rezero/mapper/recycling/CategoryMapper.java
+++ b/src/main/java/com/sch/rezero/mapper/recycling/CategoryMapper.java
@@ -3,8 +3,10 @@ package com.sch.rezero.mapper.recycling;
 import com.sch.rezero.dto.recycling.category.CategoryResponse;
 import com.sch.rezero.entity.recycling.Category;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CategoryMapper {
+    @Mapping(source = "id", target = "categoryId")
     CategoryResponse toCategoryResponse(Category category);
 }


### PR DESCRIPTION
## 제목
<!-- [태그] 작업 요약 (예: feat: 직원 등록 API 구현) -->
<!-- 태그 예시: feat, fix, refactor, docs, test, chore -->
refactor: 재활용법 글쓰기 수정

---
## 주요 변경 사항
- 카테고리 response에 id 추가해 전달될수 있도록 함
- @Lob을 제거해 text가 문자열로 저장되도록 함

---

## 관련 이슈
<!-- 관련 이슈 번호 연결 (예: Closes #12) -->


---


## 기타 공유 사항
<!-- 리뷰어가 알아야 할 추가 정보 (예: 의존성 추가, DB 마이그레이션 필요 등) -->


---
